### PR TITLE
Generate template gallery from the awesome akash repo

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -1640,6 +1640,11 @@
         "@types/node": "*"
       }
     },
+    "@types/chai": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.0.tgz",
+      "integrity": "sha512-/ceqdqeRraGolFTcfoXNiqjyQhZzbINDngeoAq9GoHa8PPK1yNzTaxWjA6BFWp5Ua9JpXEMSS4s5i9tS0hOJtw=="
+    },
     "@types/connect": {
       "version": "3.4.35",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
@@ -1766,6 +1771,11 @@
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
       "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==",
       "dev": true
+    },
+    "@types/mocha": {
+      "version": "8.2.3",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-8.2.3.tgz",
+      "integrity": "sha512-ekGvFhFgrc2zYQoX4JeZPmVzZxw6Dtllga7iGHzfbYIYkAMUx/sAFP2GdFpLff+vdHXu5fl7WX9AT+TtqYcsyw=="
     },
     "@types/node": {
       "version": "16.6.0",
@@ -7469,6 +7479,15 @@
       "dev": true,
       "requires": {
         "object-visit": "^1.0.0"
+      }
+    },
+    "markdown-to-text": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/markdown-to-text/-/markdown-to-text-0.1.1.tgz",
+      "integrity": "sha512-co/J5l8mJ2RK9wD/nQRGwO7JxoeyfvVNtOZll016EdAX2qYkwCWMdtYvJO42b41Ho7GFEJMuly9llf0Nj+ReQw==",
+      "requires": {
+        "@types/chai": "^4.2.14",
+        "@types/mocha": "^8.2.0"
       }
     },
     "media-typer": {

--- a/api/package.json
+++ b/api/package.json
@@ -31,6 +31,7 @@
     "http-proxy-middelware": "0.0.1-security",
     "js-sha256": "^0.9.0",
     "level": "^7.0.0",
+    "markdown-to-text": "^0.1.1",
     "memory-cache": "^0.2.0",
     "node-fetch": "^2.6.1",
     "protobufjs": "^6.11.2",

--- a/api/src/caching/cacheMiddleware.ts
+++ b/api/src/caching/cacheMiddleware.ts
@@ -8,9 +8,9 @@ interface CachedObject {
   body: string;
 }
 
-export default function cacheMiddleware(strDuration) {
+export default function cacheMiddleware(seconds: number) {
   return (req, res, next) => {
-    const duration = strDuration * 1000;
+    const duration = seconds * 1000;
 
     let key = "__cache__" + (req.originalUrl || req.url) + JSON.stringify(req.body);
     const cachedObject = cacheEngine.getFromCache(key) as CachedObject;

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -16,6 +16,7 @@ import { getGraphData, getDashboardData } from "./db/statsProvider";
 import * as marketDataProvider from "./providers/marketDataProvider";
 import { fetchGithubReleases } from "./providers/githubProvider";
 import { fetchProvidersInfoAtInterval, getNetworkCapacity, getProviders } from "./providers/providerStatusProvider";
+import { getTemplateGallery } from "./providers/awesomeAkashProvider";
 
 require("dotenv").config();
 
@@ -64,7 +65,17 @@ app.use(Sentry.Handlers.tracingHandler());
 const apiRouter = express.Router();
 const web3IndexRouter = express.Router();
 
-apiRouter.get("/latestDeployToolVersion", cache(120), async (req, res) => {
+apiRouter.get("/templates", cache(60 * 2), async (req, res) => {
+  try {
+    const templates = await getTemplateGallery();
+    res.send(templates);
+  } catch (err) {
+    console.error(err);
+    res.status(500).send(err?.message || err);
+  }
+});
+
+apiRouter.get("/latestDeployToolVersion", cache(60 * 2), async (req, res) => {
   try {
     const releaseData = await fetchGithubReleases();
     res.send(releaseData);

--- a/api/src/providers/awesomeAkashProvider.ts
+++ b/api/src/providers/awesomeAkashProvider.ts
@@ -1,0 +1,241 @@
+import fetch from "node-fetch";
+import removeMarkdown from "markdown-to-text";
+import path from "path";
+import { getOctokit } from "./githubProvider";
+import { isUrlAbsolute } from "@src/shared/utils/urls";
+import * as fs from "fs";
+
+const logoBaseUrl = "https://storage.googleapis.com/akashlytics-deploy-public/template_logos/";
+const logos = {
+  wordpress: "wordpress.png",
+  drupal: "drupal.png",
+  wikijs: "wikijs.svg",
+  confluence: "confluence.svg",
+  pgadmin4: "postgresql.png",
+  postgres: "postgresql.png",
+  mongoDB: "mongodb.jpg",
+  adminer: "adminer.png",
+  MySQL: "mysql.png",
+  couchdb: "couchdb.svg",
+  influxdb: "influxdb.svg",
+  odoo: "odoo.svg",
+  mattermost: "mattermost.svg",
+  jenkins: "jenkins.svg",
+  bitbucket: "bitbucket.svg",
+  "azure-devops-agent": "azure-devops.webp",
+  minecraft: "minecraft.png",
+  tetris: "tetris.webp",
+  tetris2: "tetris.webp",
+  pacman: "pacman.png",
+  supermario: "mario.png",
+  minesweeper: "minesweeper.png",
+  doom: "doom.jpg"
+};
+
+let generatingTask = null;
+let lastServedData = null;
+
+export const getTemplateGallery = async () => {
+  try {
+    const version = await fetchAwesomeAkashRepoVersion();
+    const filePath = `data/templates/${version}.json`;
+
+    if (fs.existsSync(filePath)) {
+      console.log("Serving template gallery from local cache");
+      const fileContent = fs.readFileSync(filePath, "utf8");
+      const templateGallery = JSON.parse(fileContent);
+      lastServedData = templateGallery;
+      return templateGallery;
+    }
+
+    if (generatingTask) {
+      console.log("Waiting on existing generation task to finish");
+      return await generatingTask;
+    } else {
+      generatingTask = generateTemplateGalleryAsync(version);
+      const templateGallery = await generatingTask;
+      generatingTask = null;
+
+      await fs.promises.mkdir(path.dirname(filePath), { recursive: true });
+      await fs.promises.writeFile(filePath, JSON.stringify(templateGallery, null, 2));
+
+      lastServedData = templateGallery;
+
+      return templateGallery;
+    }
+  } catch (err) {
+    if (lastServedData) {
+      console.error(err);
+      console.log("Serving template gallery from last working version");
+      return lastServedData;
+    } else {
+      throw err;
+    }
+  }
+};
+
+export const fetchAwesomeAkashRepoVersion = async () => {
+  const octokit = getOctokit();
+
+  const response = await octokit.rest.repos.getBranch({
+    owner: "ovrclk",
+    repo: "awesome-akash",
+    branch: "master"
+  });
+
+  const reqRemaining = response.headers["x-ratelimit-remaining"];
+  console.log(`${reqRemaining} requests remaining`);
+
+  if (response.status !== 200) {
+    throw new Error("Failed to fetch latest version from github");
+  }
+
+  return response.data.commit.sha;
+};
+
+export async function generateTemplateGalleryAsync(sha: string) {
+  const octokit = getOctokit();
+
+  // Fetch list of templates from README.md
+  const response = await octokit.rest.repos.getContent({
+    repo: "awesome-akash",
+    owner: "ovrclk",
+    path: "README.md",
+    ref: sha,
+    mediaType: {
+      format: "raw"
+    }
+  });
+
+  if (response.status !== 200) throw Error("Invalid response code: " + response.status);
+
+  let reqRemaining = response.headers["x-ratelimit-remaining"];
+  const data = String(response.data);
+
+  const categoryRegex = /### (.+)\n*([\w ]+)?\n*((?:- \[(?:.+)]\((?:.+)\)\n?)*)/gm;
+  const templateRegex = /(- \[(.+)]\((.+)\)\n?)/gm;
+
+  let categories = [];
+
+  // Looping through categories
+  const matches = data.matchAll(categoryRegex);
+  for (const match of matches) {
+    const title = match[1];
+    const description = match[2];
+    const templatesStr = match[3];
+
+    // Ignore duplicate categories
+    if (categories.some((x) => x.title === title)) {
+      continue;
+    }
+
+    // Extracting templates
+    const templates = [];
+    if (templatesStr) {
+      const templateMatches = templatesStr.matchAll(templateRegex);
+      for (const templateMatch of templateMatches) {
+        templates.push({
+          name: templateMatch[2],
+          path: templateMatch[3]
+        });
+      }
+    }
+
+    categories.push({
+      title: title,
+      description: description,
+      templates: templates
+    });
+  }
+
+  for (const category of categories) {
+    for (const template of category.templates) {
+      try {
+        // Ignoring templates that are not in the awesome-akash repo
+        if (template.path.startsWith("http:") || template.path.startsWith("https:")) {
+          throw "Absolute URL";
+        }
+
+        // Fetching file list in template folder
+        const response = await octokit.rest.repos.getContent({
+          repo: "awesome-akash",
+          owner: "ovrclk",
+          ref: sha,
+          path: template.path,
+          mediaType: {
+            format: "raw"
+          }
+        });
+        reqRemaining = response.headers["x-ratelimit-remaining"];
+
+        const readme = await findFileContentAsync("README.md", response.data);
+        const deploy = await findFileContentAsync(["deploy.yaml", "deploy.yml"], response.data);
+        const guide = await findFileContentAsync("GUIDE.md", response.data);
+
+        template.readme = replaceLinks(readme, "ovrclk", "awesome-akash", sha, template.path);
+        template.summary = getTemplateSummary(readme);
+        template.deploy = deploy;
+        template.guide = guide;
+        template.logoUrl = template.path in logos ? logoBaseUrl + logos[template.path] : null;
+        template.githubUrl = `https://github.com/ovrclk/awesome-akash/blob/${sha}/${template.path}`;
+        console.log(category.title + " - " + template.name);
+      } catch (err) {
+        console.warn(`Skipped ${template.name} because of error: ${err.message || err}`);
+      }
+    }
+  }
+
+  // Remove templates without "README.md" and "deploy.yml"
+  categories.forEach((c) => {
+    c.templates = c.templates.filter((x) => x.readme && x.deploy);
+  });
+  categories = categories.filter((x) => x.templates?.length > 0);
+
+  console.log("Requests remaining: " + reqRemaining);
+
+  return categories;
+}
+
+// Find a github file by name and dowload it
+async function findFileContentAsync(filename, fileList) {
+  const filenames = typeof filename === "string" ? [filename] : filename;
+  const fileDef = fileList.find((f) => filenames.some((x) => x.toLowerCase() === f.name.toLowerCase()));
+
+  if (!fileDef) return null;
+
+  const response = await fetch(fileDef.download_url);
+  const content = await response.text();
+
+  return content;
+}
+
+// Create a short summary from the README.md
+function getTemplateSummary(readme) {
+  if (!readme) return null;
+
+  const markdown = readme.replace(/^#+ .*\n+/g, "");
+  const readmeTxt = removeMarkdown(markdown);
+  const maxLength = 200;
+  const summary = readmeTxt.length > maxLength ? readmeTxt.substring(0, maxLength - 3) + "..." : readmeTxt;
+
+  return summary;
+}
+
+// Replaces local links with absolute links
+function replaceLinks(markdown, owner, repo, sha, folder) {
+  let newMarkdown = markdown;
+  const linkRegex = /!?\[([^\[]+)\]\((.*?)\)/gm;
+  const matches = newMarkdown.matchAll(linkRegex);
+  for (const match of matches) {
+    const url = match[2].startsWith("/") ? match[2].substring(1) : match[2];
+    if (isUrlAbsolute(url)) continue;
+    const isPicture = match[0].startsWith("!");
+    const absoluteUrl = isPicture
+      ? `https://raw.githubusercontent.com/${owner}/${repo}/${sha}/${folder}/` + url
+      : `https://github.com/${owner}/${repo}/blob/${sha}/${folder}/` + url;
+
+    newMarkdown = newMarkdown.split("(" + url + ")").join("(" + absoluteUrl + ")");
+  }
+
+  return newMarkdown;
+}

--- a/api/src/providers/githubProvider.ts
+++ b/api/src/providers/githubProvider.ts
@@ -1,17 +1,21 @@
 import { Octokit } from "@octokit/rest";
 
-export const fetchGithubReleases = async () => {
+export function getOctokit() {
   const githubPAT = process.env.AkashlyticsGithubPAT;
 
   if (!githubPAT) {
     throw new Error("AkashlyticsGithubPAT is missing");
   }
 
-  const octokit = new Octokit({
+  return new Octokit({
     auth: githubPAT,
     userAgent: "Akashlytics API",
     baseUrl: "https://api.github.com"
   });
+}
+
+export const fetchGithubReleases = async () => {
+  const octokit = getOctokit();
 
   const response = await octokit.rest.repos.getLatestRelease({
     owner: "Akashlytics",

--- a/api/src/shared/utils/urls.ts
+++ b/api/src/shared/utils/urls.ts
@@ -1,0 +1,21 @@
+export function isUrlAbsolute(url) {
+  if (url.indexOf("//") === 0) {
+    return true;
+  } // URL is protocol-relative (= absolute)
+  if (url.indexOf("://") === -1) {
+    return false;
+  } // URL has no protocol (= relative)
+  if (url.indexOf(".") === -1) {
+    return false;
+  } // URL does not contain a dot, i.e. no TLD (= relative, possibly REST)
+  if (url.indexOf("/") === -1) {
+    return false;
+  } // URL does not contain a single slash (= relative)
+  if (url.indexOf(":") > url.indexOf("/")) {
+    return false;
+  } // The first colon comes after the first slash (= relative)
+  if (url.indexOf("://") < url.indexOf(".")) {
+    return true;
+  } // Protocol is defined before first dot (= absolute)
+  return false; // Anything else must be relative
+}

--- a/app/src/components/Dashboard/Dashboard.component.tsx
+++ b/app/src/components/Dashboard/Dashboard.component.tsx
@@ -22,35 +22,37 @@ export const Dashboard: React.FunctionComponent<IDashboardProps> = ({ dashboardD
 
   return (
     <>
-      <Paper className={classes.priceDataContainer} elevation={2}>
-        <div className={classes.priceData}>
-          AKT{" "}
-          <div className={classes.priceDataValue}>
-            <FormattedNumber style="currency" currency="USD" value={dashboardData.marketData.price} />
-            <Box display="flex" alignItems="center" fontSize=".8rem" fontWeight={300}>
-              <DiffPercentageChip value={dashboardData.marketData.priceChangePercentage24 / 100} />
-              <Box component="span" ml=".5rem">
-                (24h)
+      {dashboardData.marketData && (
+        <Paper className={classes.priceDataContainer} elevation={2}>
+          <div className={classes.priceData}>
+            AKT{" "}
+            <div className={classes.priceDataValue}>
+              <FormattedNumber style="currency" currency="USD" value={dashboardData.marketData.price} />
+              <Box display="flex" alignItems="center" fontSize=".8rem" fontWeight={300}>
+                <DiffPercentageChip value={dashboardData.marketData.priceChangePercentage24 / 100} />
+                <Box component="span" ml=".5rem">
+                  (24h)
+                </Box>
               </Box>
-            </Box>
+            </div>
           </div>
-        </div>
-        <div className={classes.priceData}>
-          <span>Market cap</span>{" "}
-          <span className={classes.priceDataValue}>
-            <FormattedNumber style="currency" currency="USD" value={dashboardData.marketData.marketCap} minimumFractionDigits={0} maximumFractionDigits={0} />
-          </span>
-        </div>
-        <div className={classes.priceData}>
-          <span>Volume (24h)</span>{" "}
-          <span className={classes.priceDataValue}>
-            <FormattedNumber style="currency" currency="USD" value={dashboardData.marketData.volume} minimumFractionDigits={0} maximumFractionDigits={0} />
-          </span>
-        </div>
-        <div className={classes.priceData}>
-          <span>Rank</span> <span className={classes.priceDataValue}>{dashboardData.marketData.marketCapRank}</span>
-        </div>
-      </Paper>
+          <div className={classes.priceData}>
+            <span>Market cap</span>{" "}
+            <span className={classes.priceDataValue}>
+              <FormattedNumber style="currency" currency="USD" value={dashboardData.marketData.marketCap} minimumFractionDigits={0} maximumFractionDigits={0} />
+            </span>
+          </div>
+          <div className={classes.priceData}>
+            <span>Volume (24h)</span>{" "}
+            <span className={classes.priceDataValue}>
+              <FormattedNumber style="currency" currency="USD" value={dashboardData.marketData.volume} minimumFractionDigits={0} maximumFractionDigits={0} />
+            </span>
+          </div>
+          <div className={classes.priceData}>
+            <span>Rank</span> <span className={classes.priceDataValue}>{dashboardData.marketData.marketCapRank}</span>
+          </div>
+        </Paper>
+      )}
 
       <div
         className={clsx("row", {


### PR DESCRIPTION
- Fetch the templates from the awesome-akash-repo and consolidate into a json file
- The generated file is cached based on the repo version (sha of the latest commit)
- There is a 2 minutes memory cache to prevent querying github too many times (for looking up the latest version)
- Added a check in the web app to hide market data stats if they are not available (instead of crashing the entire page)