### PR TITLE
Improve stats precision for "out of funds" leases

### DIFF
--- a/api/src/akash/statsProcessor.ts
+++ b/api/src/akash/statsProcessor.ts
@@ -417,9 +417,7 @@ class StatsProcessor {
         dseq: decodedMessage.id.dseq.toNumber(),
         deposit: parseInt(decodedMessage.deposit.amount),
         balance: parseInt(decodedMessage.deposit.amount),
-        createdHeight: height,
-        state: "-",
-        escrowAccountTransferredAmount: 0
+        createdHeight: height
       },
       { transaction: blockGroupTransaction }
     );
@@ -467,9 +465,7 @@ class StatsProcessor {
         dseq: decodedMessage.id.dseq.toNumber(),
         deposit: parseInt(decodedMessage.deposit.amount),
         balance: parseInt(decodedMessage.deposit.amount),
-        createdHeight: height,
-        state: "-",
-        escrowAccountTransferredAmount: 0
+        createdHeight: height
       },
       { transaction: blockGroupTransaction }
     );

--- a/api/src/akash/statsProcessor.ts
+++ b/api/src/akash/statsProcessor.ts
@@ -35,6 +35,8 @@ import {
 } from "@src/db/schema";
 import { AuthInfo, TxBody, TxRaw } from "cosmjs-types/cosmos/tx/v1beta1/tx";
 import * as benchmark from "../shared/utils/benchmark";
+import { accountSettle } from "@src/shared/utils/akashPaymentSettle";
+import { lastBlockToSync } from "@src/shared/constants";
 
 export let processingStatus = null;
 
@@ -162,8 +164,8 @@ class StatsProcessor {
     });
 
     let firstBlockToProcess = firstUnprocessedHeight;
-    let lastBlockToProcess = Math.min(lastUnprocessedHeight, firstBlockToProcess + groupSize);
-    while (firstBlockToProcess <= lastUnprocessedHeight) {
+    let lastBlockToProcess = Math.min(lastUnprocessedHeight, firstBlockToProcess + groupSize, lastBlockToSync);
+    while (firstBlockToProcess <= Math.min(lastUnprocessedHeight, lastBlockToSync)) {
       console.log(`Loading blocks ${firstBlockToProcess} to ${lastBlockToProcess}`);
 
       const getBlocksTimer = benchmark.startTimer("getBlocks");
@@ -303,7 +305,7 @@ class StatsProcessor {
       }
 
       firstBlockToProcess += groupSize;
-      lastBlockToProcess = Math.min(lastUnprocessedHeight, firstBlockToProcess + groupSize);
+      lastBlockToProcess = Math.min(lastUnprocessedHeight, firstBlockToProcess + groupSize, lastBlockToSync);
     }
 
     processingStatus = null;
@@ -397,7 +399,7 @@ class StatsProcessor {
     "/akash.audit.v1beta2.MsgDeleteProviderAttributes": this.handleDeleteSignProviderAttributes
   };
 
-  private async processMessage(msg, encodedMessage, height: number,blockGroupTransaction) {
+  private async processMessage(msg, encodedMessage, height: number, blockGroupTransaction) {
     if (!Object.keys(this.messageHandlers).includes(msg.type)) {
       throw Error("No handler for message of type: " + msg.type);
     }
@@ -407,7 +409,7 @@ class StatsProcessor {
     });
   }
 
-  private async handleCreateDeployment(encodedMessage, height: number,blockGroupTransaction, msg: Message) {
+  private async handleCreateDeployment(encodedMessage, height: number, blockGroupTransaction, msg: Message) {
     const decodedMessage = MsgCreateDeployment.decode(encodedMessage);
 
     const created = await Deployment.create(
@@ -417,7 +419,9 @@ class StatsProcessor {
         dseq: decodedMessage.id.dseq.toNumber(),
         deposit: parseInt(decodedMessage.deposit.amount),
         balance: parseInt(decodedMessage.deposit.amount),
-        createdHeight: height
+        withdrawnAmount: 0,
+        createdHeight: height,
+        closedHeight: null
       },
       { transaction: blockGroupTransaction }
     );
@@ -455,7 +459,7 @@ class StatsProcessor {
     }
   }
 
-  private async handleCreateDeploymentV2(encodedMessage, height: number,blockGroupTransaction, msg: Message) {
+  private async handleCreateDeploymentV2(encodedMessage, height: number, blockGroupTransaction, msg: Message) {
     const decodedMessage = v1beta2.MsgCreateDeployment.decode(encodedMessage);
 
     const created = await Deployment.create(
@@ -465,7 +469,9 @@ class StatsProcessor {
         dseq: decodedMessage.id.dseq.toNumber(),
         deposit: parseInt(decodedMessage.deposit.amount),
         balance: parseInt(decodedMessage.deposit.amount),
-        createdHeight: height
+        withdrawnAmount: 0,
+        createdHeight: height,
+        closedHeight: null
       },
       { transaction: blockGroupTransaction }
     );
@@ -503,42 +509,33 @@ class StatsProcessor {
     }
   }
 
-  private async handleCloseDeployment(encodedMessage, height: number,blockGroupTransaction, msg: Message) {
+  private async handleCloseDeployment(encodedMessage, height: number, blockGroupTransaction, msg: Message) {
     const decodedMessage = MsgCloseDeployment.decode(encodedMessage);
 
     const deployment = await Deployment.findOne({
       where: {
         id: getDeploymentIdFromCache(decodedMessage.id.owner, decodedMessage.id.dseq.toNumber())
       },
-      include: [
-        {
-          model: Lease,
-          required: false,
-          where: {
-            closedHeight: { [Op.is]: null }
-          }
-        }
-      ],
+      include: [{ model: Lease }],
       transaction: blockGroupTransaction
     });
 
     msg.relatedDeploymentId = deployment.id;
 
-    for (let lease of deployment.leases) {
-      const startBlock = lease.lastWithdrawHeight || lease.createdHeight;
-      const blockCount = height - startBlock;
-      const amount = Math.min(lease.price * blockCount, deployment.balance); // TODO : Handle proportional distribution
+    await accountSettle(deployment, height, blockGroupTransaction);
 
-      lease.withdrawnAmount += amount;
-      lease.lastWithdrawHeight = height;
-      deployment.balance -= amount;
-
-      lease.closedHeight = height;
-      await lease.save({ transaction: blockGroupTransaction });
+    for (const lease of deployment.leases) {
+      if (!lease.closedHeight) {
+        lease.closedHeight = height;
+        await lease.save({ transaction: blockGroupTransaction });
+      }
     }
+
+    deployment.closedHeight = height;
+    await deployment.save({ transaction: blockGroupTransaction });
   }
 
-  private async handleCreateLease(encodedMessage, height: number,blockGroupTransaction, msg: Message) {
+  private async handleCreateLease(encodedMessage, height: number, blockGroupTransaction, msg: Message) {
     const decodedMessage = MsgCreateLease.decode(encodedMessage);
     const bid = await Bid.findOne({
       where: {
@@ -563,13 +560,16 @@ class StatsProcessor {
     const deploymentId = getDeploymentIdFromCache(decodedMessage.bid_id.owner, decodedMessage.bid_id.dseq.toNumber());
 
     const deployment = await Deployment.findOne({
-      attributes: ["balance"],
       where: {
         id: deploymentId
       },
+      include: [{ model: Lease }],
       transaction: blockGroupTransaction
     });
-    const predictedClosedHeight = Math.ceil(height + deployment.balance / bid.price);
+
+    const { blockRate } = await accountSettle(deployment, height, blockGroupTransaction);
+
+    const predictedClosedHeight = Math.ceil(height + deployment.balance / (blockRate + bid.price));
 
     await Lease.create(
       {
@@ -593,44 +593,47 @@ class StatsProcessor {
       { transaction: blockGroupTransaction }
     );
 
+    await Lease.update({ predictedClosedHeight: predictedClosedHeight }, { where: { deploymentId: deploymentId }, transaction: blockGroupTransaction });
+
     msg.relatedDeploymentId = deploymentId;
 
     this.totalLeaseCount++;
   }
 
-  private async handleCloseLease(encodedMessage, height: number,blockGroupTransaction, msg: Message) {
+  private async handleCloseLease(encodedMessage, height: number, blockGroupTransaction, msg: Message) {
     const decodedMessage = MsgCloseLease.decode(encodedMessage);
 
-    let lease = await Lease.findOne({
+    const deployment = await Deployment.findOne({
       where: {
-        deploymentId: getDeploymentIdFromCache(decodedMessage.lease_id.owner, decodedMessage.lease_id.dseq.toNumber()),
-        oseq: decodedMessage.lease_id.oseq,
-        gseq: decodedMessage.lease_id.gseq,
-        provider: decodedMessage.lease_id.provider,
-        closedHeight: { [Op.is]: null }
+        id: getDeploymentIdFromCache(decodedMessage.lease_id.owner, decodedMessage.lease_id.dseq.toNumber())
       },
-      include: {
-        model: Deployment
-      },
+      include: [{ model: Lease }],
       transaction: blockGroupTransaction
     });
 
-    msg.relatedDeploymentId = lease.deployment.id;
+    const lease = deployment.leases.find(
+      (x) => x.oseq === decodedMessage.lease_id.oseq && x.gseq === decodedMessage.lease_id.gseq && x.provider === decodedMessage.lease_id.provider
+    );
 
-    const startBlock = lease.lastWithdrawHeight || lease.createdHeight;
-    const blockCount = height - startBlock;
-    const amount = Math.min(lease.price * blockCount, lease.deployment.balance); // TODO : Handle proportional distribution
+    if (!lease) throw new Error("Lease not found");
 
-    lease.withdrawnAmount += amount;
-    lease.lastWithdrawHeight = height;
-    lease.deployment.balance -= amount;
+    msg.relatedDeploymentId = deployment.id;
+
+    const { blockRate } = await accountSettle(deployment, height, blockGroupTransaction);
 
     lease.closedHeight = height;
     await lease.save({ transaction: blockGroupTransaction });
-    await lease.deployment.save({ transaction: blockGroupTransaction });
+
+    if (!deployment.leases.some((x) => !x.closedHeight)) {
+      deployment.closedHeight = height;
+      await deployment.save({ transaction: blockGroupTransaction });
+    } else {
+      const predictedClosedHeight = deployment.balance / (blockRate - lease.price);
+      await Lease.update({ predictedClosedHeight: predictedClosedHeight }, { where: { deploymentId: deployment.id }, transaction: blockGroupTransaction });
+    }
   }
 
-  private async handleCreateBid(encodedMessage, height: number,blockGroupTransaction, msg: Message) {
+  private async handleCreateBid(encodedMessage, height: number, blockGroupTransaction, msg: Message) {
     const decodedMessage = MsgCreateBid.decode(encodedMessage);
 
     await Bid.create(
@@ -649,7 +652,7 @@ class StatsProcessor {
     msg.relatedDeploymentId = getDeploymentIdFromCache(decodedMessage.order_id.owner, decodedMessage.order_id.dseq.toNumber());
   }
 
-  private async handleCreateBidV2(encodedMessage, height: number,blockGroupTransaction, msg: Message) {
+  private async handleCreateBidV2(encodedMessage, height: number, blockGroupTransaction, msg: Message) {
     const decodedMessage = v1beta2.MsgCreateBid.decode(encodedMessage);
 
     await Bid.create(
@@ -668,39 +671,36 @@ class StatsProcessor {
     msg.relatedDeploymentId = getDeploymentIdFromCache(decodedMessage.order_id.owner, decodedMessage.order_id.dseq.toNumber());
   }
 
-  private async handleCloseBid(encodedMessage, height: number,blockGroupTransaction, msg: Message) {
+  private async handleCloseBid(encodedMessage, height: number, blockGroupTransaction, msg: Message) {
     const decodedMessage = MsgCloseBid.decode(encodedMessage);
 
     const deployment = await Deployment.findOne({
       where: {
         id: getDeploymentIdFromCache(decodedMessage.bid_id.owner, decodedMessage.bid_id.dseq.toNumber())
       },
-      include: {
-        model: Lease,
-        required: false,
-        where: {
-          closedHeight: { [Op.is]: null },
-          gseq: decodedMessage.bid_id.gseq,
-          oseq: decodedMessage.bid_id.oseq,
-          provider: decodedMessage.bid_id.provider
-        }
-      },
+      include: [{ model: Lease }],
       transaction: blockGroupTransaction
     });
 
     msg.relatedDeploymentId = deployment.id;
 
-    for (let lease of deployment.leases) {
-      const startBlock = lease.lastWithdrawHeight || lease.createdHeight;
-      const blockCount = height - startBlock;
-      const amount = Math.min(lease.price * blockCount, deployment.balance); // TODO : Handle proportional distribution
+    const lease = deployment.leases.find(
+      (x) => x.oseq === decodedMessage.bid_id.oseq && x.gseq === decodedMessage.bid_id.gseq && x.provider === decodedMessage.bid_id.provider
+    );
 
-      lease.withdrawnAmount += amount;
-      lease.lastWithdrawHeight = height;
-      deployment.balance -= amount;
+    if (lease) {
+      const { blockRate } = await accountSettle(deployment, height, blockGroupTransaction);
 
       lease.closedHeight = height;
       await lease.save({ transaction: blockGroupTransaction });
+
+      if (!deployment.leases.some((x) => !x.closedHeight)) {
+        deployment.closedHeight = height;
+        await deployment.save({ transaction: blockGroupTransaction });
+      } else {
+        const predictedClosedHeight = deployment.balance / (blockRate - lease.price);
+        await Lease.update({ predictedClosedHeight: predictedClosedHeight }, { where: { deploymentId: deployment.id }, transaction: blockGroupTransaction });
+      }
     }
 
     await Bid.destroy({
@@ -715,7 +715,7 @@ class StatsProcessor {
     });
   }
 
-  private async handleDepositDeployment(encodedMessage, height: number,blockGroupTransaction, msg: Message) {
+  private async handleDepositDeployment(encodedMessage, height: number, blockGroupTransaction, msg: Message) {
     const decodedMessage = MsgDepositDeployment.decode(encodedMessage);
 
     const deployment = await Deployment.findOne({
@@ -736,61 +736,47 @@ class StatsProcessor {
     deployment.balance += parseFloat(decodedMessage.amount.amount);
     await deployment.save({ transaction: blockGroupTransaction });
 
+    const blockRate = deployment.leases
+      .filter((x) => !x.closedHeight)
+      .map((x) => x.price)
+      .reduce((a, b) => a + b, 0);
+
     for (const lease of deployment.leases) {
-      lease.predictedClosedHeight = Math.ceil((lease.lastWithdrawHeight || lease.createdHeight) + deployment.balance / lease.price);
+      lease.predictedClosedHeight = Math.ceil((deployment.lastWithdrawHeight || lease.createdHeight) + deployment.balance / blockRate);
       await lease.save({ transaction: blockGroupTransaction });
     }
   }
 
-  private async handleWithdrawLease(encodedMessage, height: number,blockGroupTransaction, msg: Message) {
+  private async handleWithdrawLease(encodedMessage, height: number, blockGroupTransaction, msg: Message) {
     const decodedMessage = MsgWithdrawLease.decode(encodedMessage);
 
     const owner = decodedMessage.lease_id.owner;
     const dseq = decodedMessage.lease_id.dseq.toNumber();
+    const gseq = decodedMessage.lease_id.gseq;
+    const oseq = decodedMessage.lease_id.oseq;
+    const provider = decodedMessage.lease_id.provider;
 
-    let lease = await Lease.findOne({
-      attributes: ["id", "price", "lastWithdrawHeight", "createdHeight", "withdrawnAmount"],
+    const deployment = await Deployment.findOne({
       where: {
         owner: owner,
-        dseq: dseq,
-        gseq: decodedMessage.lease_id.gseq,
-        oseq: decodedMessage.lease_id.oseq
+        dseq: dseq
       },
-      include: {
-        model: Deployment,
-        attributes: ["id", "balance"]
-      },
+      include: [{ model: Lease }],
       transaction: blockGroupTransaction
     });
-
-    const startBlock = lease.lastWithdrawHeight || lease.createdHeight;
-    const blockCount = height - startBlock;
-    const amount = Math.min(lease.price * blockCount, lease.deployment.balance);
-    lease.withdrawnAmount += amount;
-    lease.lastWithdrawHeight = height;
-    lease.deployment.balance -= amount;
-    await lease.save({ transaction: blockGroupTransaction });
-
-    if (lease.deployment.balance <= 0) {
-      await Lease.update(
-        {
-          closedHeight: height
-        },
-        {
-          where: {
-            deploymentId: getDeploymentIdFromCache(owner, dseq)
-          },
-          transaction: blockGroupTransaction
-        }
-      );
-    }
-
-    await lease.deployment.save({ transaction: blockGroupTransaction });
-
-    msg.relatedDeploymentId = lease.deployment.id;
+  
+    if (!deployment) throw new Error(`Deployment not found for owner: ${owner} and dseq: ${dseq}`);
+  
+    const lease = deployment.leases.find((x) => x.gseq === gseq && x.oseq === oseq && x.provider === provider);
+  
+    if (!lease) throw new Error(`Lease not found for gseq: ${gseq}, oseq: ${oseq} and provider: ${provider}`);
+  
+    await accountSettle(deployment, height, blockGroupTransaction);
+  
+    msg.relatedDeploymentId = deployment.id;
   }
 
-  private async handleCreateProvider(encodedMessage, height: number,blockGroupTransaction, msg: Message) {
+  private async handleCreateProvider(encodedMessage, height: number, blockGroupTransaction, msg: Message) {
     const decodedMessage = MsgCreateProvider.decode(encodedMessage);
 
     await Provider.create(
@@ -816,7 +802,7 @@ class StatsProcessor {
     this.activeProviderCount++;
   }
 
-  private async handleUpdateProvider(encodedMessage, height: number,blockGroupTransaction, msg: Message) {
+  private async handleUpdateProvider(encodedMessage, height: number, blockGroupTransaction, msg: Message) {
     const decodedMessage = MsgUpdateProvider.decode(encodedMessage);
 
     await Provider.update(
@@ -850,7 +836,7 @@ class StatsProcessor {
     );
   }
 
-  private async handleDeleteProvider(encodedMessage, height: number,blockGroupTransaction, msg: Message) {
+  private async handleDeleteProvider(encodedMessage, height: number, blockGroupTransaction, msg: Message) {
     const decodedMessage = MsgDeleteProvider.decode(encodedMessage);
 
     await Provider.destroy({

--- a/api/src/akash/statsProcessor.ts
+++ b/api/src/akash/statsProcessor.ts
@@ -764,15 +764,15 @@ class StatsProcessor {
       include: [{ model: Lease }],
       transaction: blockGroupTransaction
     });
-  
+
     if (!deployment) throw new Error(`Deployment not found for owner: ${owner} and dseq: ${dseq}`);
-  
+
     const lease = deployment.leases.find((x) => x.gseq === gseq && x.oseq === oseq && x.provider === provider);
-  
+
     if (!lease) throw new Error(`Lease not found for gseq: ${gseq}, oseq: ${oseq} and provider: ${provider}`);
-  
+
     await accountSettle(deployment, height, blockGroupTransaction);
-  
+
     msg.relatedDeploymentId = deployment.id;
   }
 

--- a/api/src/akash/statsProcessor.ts
+++ b/api/src/akash/statsProcessor.ts
@@ -397,7 +397,7 @@ class StatsProcessor {
     "/akash.audit.v1beta2.MsgDeleteProviderAttributes": this.handleDeleteSignProviderAttributes
   };
 
-  private async processMessage(msg, encodedMessage, height, blockGroupTransaction) {
+  private async processMessage(msg, encodedMessage, height: number,blockGroupTransaction) {
     if (!Object.keys(this.messageHandlers).includes(msg.type)) {
       throw Error("No handler for message of type: " + msg.type);
     }
@@ -407,7 +407,7 @@ class StatsProcessor {
     });
   }
 
-  private async handleCreateDeployment(encodedMessage, height, blockGroupTransaction, msg: Message) {
+  private async handleCreateDeployment(encodedMessage, height: number,blockGroupTransaction, msg: Message) {
     const decodedMessage = MsgCreateDeployment.decode(encodedMessage);
 
     const created = await Deployment.create(
@@ -455,7 +455,7 @@ class StatsProcessor {
     }
   }
 
-  private async handleCreateDeploymentV2(encodedMessage, height, blockGroupTransaction, msg: Message) {
+  private async handleCreateDeploymentV2(encodedMessage, height: number,blockGroupTransaction, msg: Message) {
     const decodedMessage = v1beta2.MsgCreateDeployment.decode(encodedMessage);
 
     const created = await Deployment.create(
@@ -503,7 +503,7 @@ class StatsProcessor {
     }
   }
 
-  private async handleCloseDeployment(encodedMessage, height, blockGroupTransaction, msg: Message) {
+  private async handleCloseDeployment(encodedMessage, height: number,blockGroupTransaction, msg: Message) {
     const decodedMessage = MsgCloseDeployment.decode(encodedMessage);
 
     const deployment = await Deployment.findOne({
@@ -538,7 +538,7 @@ class StatsProcessor {
     }
   }
 
-  private async handleCreateLease(encodedMessage, height, blockGroupTransaction, msg: Message) {
+  private async handleCreateLease(encodedMessage, height: number,blockGroupTransaction, msg: Message) {
     const decodedMessage = MsgCreateLease.decode(encodedMessage);
     const bid = await Bid.findOne({
       where: {
@@ -598,7 +598,7 @@ class StatsProcessor {
     this.totalLeaseCount++;
   }
 
-  private async handleCloseLease(encodedMessage, height, blockGroupTransaction, msg: Message) {
+  private async handleCloseLease(encodedMessage, height: number,blockGroupTransaction, msg: Message) {
     const decodedMessage = MsgCloseLease.decode(encodedMessage);
 
     let lease = await Lease.findOne({
@@ -630,7 +630,7 @@ class StatsProcessor {
     await lease.deployment.save({ transaction: blockGroupTransaction });
   }
 
-  private async handleCreateBid(encodedMessage, height, blockGroupTransaction, msg: Message) {
+  private async handleCreateBid(encodedMessage, height: number,blockGroupTransaction, msg: Message) {
     const decodedMessage = MsgCreateBid.decode(encodedMessage);
 
     await Bid.create(
@@ -649,7 +649,7 @@ class StatsProcessor {
     msg.relatedDeploymentId = getDeploymentIdFromCache(decodedMessage.order_id.owner, decodedMessage.order_id.dseq.toNumber());
   }
 
-  private async handleCreateBidV2(encodedMessage, height, blockGroupTransaction, msg: Message) {
+  private async handleCreateBidV2(encodedMessage, height: number,blockGroupTransaction, msg: Message) {
     const decodedMessage = v1beta2.MsgCreateBid.decode(encodedMessage);
 
     await Bid.create(
@@ -668,7 +668,7 @@ class StatsProcessor {
     msg.relatedDeploymentId = getDeploymentIdFromCache(decodedMessage.order_id.owner, decodedMessage.order_id.dseq.toNumber());
   }
 
-  private async handleCloseBid(encodedMessage, height, blockGroupTransaction, msg: Message) {
+  private async handleCloseBid(encodedMessage, height: number,blockGroupTransaction, msg: Message) {
     const decodedMessage = MsgCloseBid.decode(encodedMessage);
 
     const deployment = await Deployment.findOne({
@@ -715,7 +715,7 @@ class StatsProcessor {
     });
   }
 
-  private async handleDepositDeployment(encodedMessage, height, blockGroupTransaction, msg: Message) {
+  private async handleDepositDeployment(encodedMessage, height: number,blockGroupTransaction, msg: Message) {
     const decodedMessage = MsgDepositDeployment.decode(encodedMessage);
 
     const deployment = await Deployment.findOne({
@@ -742,7 +742,7 @@ class StatsProcessor {
     }
   }
 
-  private async handleWithdrawLease(encodedMessage, height, blockGroupTransaction, msg: Message) {
+  private async handleWithdrawLease(encodedMessage, height: number,blockGroupTransaction, msg: Message) {
     const decodedMessage = MsgWithdrawLease.decode(encodedMessage);
 
     const owner = decodedMessage.lease_id.owner;
@@ -790,7 +790,7 @@ class StatsProcessor {
     msg.relatedDeploymentId = lease.deployment.id;
   }
 
-  private async handleCreateProvider(encodedMessage, height, blockGroupTransaction, msg: Message) {
+  private async handleCreateProvider(encodedMessage, height: number,blockGroupTransaction, msg: Message) {
     const decodedMessage = MsgCreateProvider.decode(encodedMessage);
 
     await Provider.create(
@@ -816,7 +816,7 @@ class StatsProcessor {
     this.activeProviderCount++;
   }
 
-  private async handleUpdateProvider(encodedMessage, height, blockGroupTransaction, msg: Message) {
+  private async handleUpdateProvider(encodedMessage, height: number,blockGroupTransaction, msg: Message) {
     const decodedMessage = MsgUpdateProvider.decode(encodedMessage);
 
     await Provider.update(
@@ -850,7 +850,7 @@ class StatsProcessor {
     );
   }
 
-  private async handleDeleteProvider(encodedMessage, height, blockGroupTransaction, msg: Message) {
+  private async handleDeleteProvider(encodedMessage, height: number,blockGroupTransaction, msg: Message) {
     const decodedMessage = MsgDeleteProvider.decode(encodedMessage);
 
     await Provider.destroy({
@@ -871,7 +871,7 @@ class StatsProcessor {
     this.activeProviderCount--;
   }
 
-  private async handleSignProviderAttributes(encodedMessage, height, blockGroupTransaction, msg: Message) {
+  private async handleSignProviderAttributes(encodedMessage, height: number, blockGroupTransaction, msg: Message) {
     const decodedMessage = MsgSignProviderAttributes.decode(encodedMessage);
 
     const provider = await Provider.findOne({ where: { owner: decodedMessage.owner }, transaction: blockGroupTransaction });
@@ -912,7 +912,7 @@ class StatsProcessor {
     }
   }
 
-  private async handleDeleteSignProviderAttributes(encodedMessage, height, blockGroupTransaction, msg: Message) {
+  private async handleDeleteSignProviderAttributes(encodedMessage, height: number, blockGroupTransaction, msg: Message) {
     const decodedMessage = MsgDeleteProviderAttributes.decode(encodedMessage);
 
     await ProviderAttributeSignature.destroy({

--- a/api/src/db/schema.ts
+++ b/api/src/db/schema.ts
@@ -176,8 +176,6 @@ export class Deployment extends Model {
   public id!: string;
   public owner!: string;
   public dseq!: number;
-  public state?: string;
-  public escrowAccountTransferredAmount?: number;
   public createdHeight!: number;
   public balance!: number;
   public deposit!: number;
@@ -189,10 +187,8 @@ Deployment.init(
     id: { type: DataTypes.UUID, defaultValue: UUIDV4, primaryKey: true, allowNull: false },
     owner: { type: DataTypes.STRING, allowNull: false },
     dseq: { type: DataTypes.INTEGER, allowNull: false },
-    state: { type: DataTypes.STRING, allowNull: false },
-    escrowAccountTransferredAmount: { type: DataTypes.INTEGER, allowNull: false },
     createdHeight: { type: DataTypes.INTEGER, allowNull: false },
-    balance: { type: DataTypes.INTEGER, allowNull: false },
+    balance: { type: DataTypes.DECIMAL, allowNull: false },
     deposit: { type: DataTypes.INTEGER, allowNull: false }
   },
   {

--- a/api/src/db/schema.ts
+++ b/api/src/db/schema.ts
@@ -130,7 +130,6 @@ export class Lease extends Model {
   public predictedClosedHeight!: number;
   public price!: number;
   public withdrawnAmount!: number;
-  public lastWithdrawHeight?: number;
 
   // Stats
   cpuUnits: number;
@@ -153,7 +152,6 @@ Lease.init(
     predictedClosedHeight: { type: DataTypes.INTEGER, allowNull: false },
     price: { type: DataTypes.INTEGER, allowNull: false },
     withdrawnAmount: { type: DataTypes.INTEGER, defaultValue: 0, allowNull: false },
-    lastWithdrawHeight: { type: DataTypes.INTEGER, allowNull: true },
     // Stats
     cpuUnits: { type: DataTypes.INTEGER, allowNull: false },
     memoryQuantity: { type: DataTypes.BIGINT, allowNull: false },
@@ -179,6 +177,10 @@ export class Deployment extends Model {
   public createdHeight!: number;
   public balance!: number;
   public deposit!: number;
+  public lastWithdrawHeight?: number;
+  public withdrawnAmount!: number;
+  public closedHeight?: number;
+
   public readonly leases?: Lease[];
 }
 
@@ -189,7 +191,10 @@ Deployment.init(
     dseq: { type: DataTypes.INTEGER, allowNull: false },
     createdHeight: { type: DataTypes.INTEGER, allowNull: false },
     balance: { type: DataTypes.DECIMAL, allowNull: false },
-    deposit: { type: DataTypes.INTEGER, allowNull: false }
+    deposit: { type: DataTypes.INTEGER, allowNull: false },
+    lastWithdrawHeight: { type: DataTypes.INTEGER, allowNull: true },
+    withdrawnAmount: { type: DataTypes.DECIMAL, allowNull: false },
+    closedHeight: { type: DataTypes.INTEGER, allowNull: true }
   },
   {
     tableName: "deployment",

--- a/api/src/shared/constants.ts
+++ b/api/src/shared/constants.ts
@@ -9,7 +9,7 @@ export enum ExecutionMode {
   RebuildAll
 }
 
-export const executionMode: ExecutionMode = isProd ? ExecutionMode.DownloadAndSync : ExecutionMode.SyncOnly;
+export const executionMode: ExecutionMode = isProd ? ExecutionMode.DownloadAndSync : ExecutionMode.RebuildStats;
 export const lastBlockToSync = Number.POSITIVE_INFINITY;
 
 export const mainNet = "https://raw.githubusercontent.com/ovrclk/net/master/mainnet";

--- a/api/src/shared/constants.ts
+++ b/api/src/shared/constants.ts
@@ -9,7 +9,7 @@ export enum ExecutionMode {
   RebuildAll
 }
 
-export const executionMode: ExecutionMode = isProd ? ExecutionMode.DownloadAndSync : ExecutionMode.RebuildStats;
+export const executionMode: ExecutionMode = isProd ? ExecutionMode.DownloadAndSync : ExecutionMode.SyncOnly;
 export const lastBlockToSync = Number.POSITIVE_INFINITY;
 
 export const mainNet = "https://raw.githubusercontent.com/ovrclk/net/master/mainnet";

--- a/api/src/shared/utils/akashPaymentSettle.ts
+++ b/api/src/shared/utils/akashPaymentSettle.ts
@@ -1,0 +1,99 @@
+// This copies the logic of the akash node
+
+import { Deployment, Lease } from "@src/db/schema";
+
+// Port of https://github.com/ovrclk/akash/blob/c2be64614f7417cf99447185f9d13b49bf33dadb/x/escrow/keeper/keeper.go#L353
+export async function accountSettle(deployment: Deployment, height: number, blockGroupTransaction): Promise<{ blockRate: number }> {
+  if (!deployment) throw new Error("Deployment is missing");
+  if (!deployment.leases) throw new Error("Deployment.leases is missing");
+
+  const activeLeases = deployment.leases.filter((x) => !x.closedHeight);
+  const blockRate = activeLeases.map((x) => x.price).reduce((a, b) => a + b, 0);
+
+  if (height === deployment.lastWithdrawHeight) return { blockRate };
+
+  const heightDelta = height - deployment.lastWithdrawHeight;
+
+  deployment.lastWithdrawHeight = height;
+
+  if (activeLeases.length === 0) {
+    await deployment.save({ transaction: blockGroupTransaction });
+    return { blockRate: 0 };
+  }
+
+  const { overdrawn, remaining } = accountSettleFullBlocks(deployment, activeLeases, heightDelta, blockRate);
+
+  if (!overdrawn) {
+    await deployment.save({ transaction: blockGroupTransaction });
+    for (const lease of activeLeases) {
+      await lease.save({ transaction: blockGroupTransaction });
+    }
+
+    return { blockRate };
+  }
+
+  // Overdrawn
+
+  const newRemaining = accountSettleDistributeWeighted(deployment, activeLeases, blockRate, remaining);
+
+  if (newRemaining > 1) {
+    throw new Error(`Invalid settlement: ${newRemaining} remains`);
+  }
+
+  deployment.closedHeight = height;
+  await deployment.save({ transaction: blockGroupTransaction });
+  for (const lease of activeLeases) {
+    lease.closedHeight = height;
+    await lease.save({ transaction: blockGroupTransaction });
+  }
+
+  return { blockRate };
+}
+
+// Port of https://github.com/ovrclk/akash/blob/c2be64614f7417cf99447185f9d13b49bf33dadb/x/escrow/keeper/keeper.go#L543
+function accountSettleFullBlocks(
+  deployment: Deployment,
+  activeLeases: Lease[],
+  heightDelta: number,
+  blockRate: number
+): { overdrawn: boolean; remaining: number } {
+  let numFullBlocks = Math.min(Math.floor(deployment.balance / blockRate), heightDelta);
+
+  for (const lease of activeLeases) {
+    lease.withdrawnAmount += numFullBlocks * lease.price;
+  }
+
+  const transferred = blockRate * numFullBlocks;
+
+  deployment.withdrawnAmount += transferred;
+  deployment.balance -= transferred;
+
+  let remaining = deployment.balance;
+  let overdrawn = true;
+  if (numFullBlocks === heightDelta) {
+    remaining = 0;
+    overdrawn = false;
+  }
+
+  if (overdrawn) {
+    deployment.balance = remaining;
+  }
+
+  return { overdrawn, remaining };
+}
+
+// Port of https://github.com/ovrclk/akash/blob/c2be64614f7417cf99447185f9d13b49bf33dadb/x/escrow/keeper/keeper.go#L594
+function accountSettleDistributeWeighted(deployment: Deployment, activeLeases: Lease[], blockRate: number, remaining: number) {
+  let transferred = 0;
+
+  for (const lease of activeLeases) {
+    const amount = (remaining * lease.price) / blockRate;
+    lease.withdrawnAmount += amount;
+    transferred += amount;
+  }
+
+  deployment.withdrawnAmount += transferred;
+  deployment.balance -= transferred;
+
+  return remaining - transferred;
+}


### PR DESCRIPTION
- Porting the `accountSettle` method from the [akash cli](https://github.com/ovrclk/akash/blob/c2be64614f7417cf99447185f9d13b49bf33dadb/x/escrow/keeper/keeper.go#L353) to better predict when a lease will be "out of fund"
- Remove unused columns